### PR TITLE
Fix for latest radarr release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,25 @@ MAINTAINER hotio
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install
-RUN apt-get update && \
-    apt-get install -y \
-        libcurl3 \
-        libsqlite3-0 \
-        libmono-cil-dev \
-        mediainfo && \
-
-    jobid=$(curl -s "https://ci.appveyor.com/api/projects/galli-leo/radarr-usby1/branch/develop" | jq -r '.build.jobs[0].jobId') && \
-    filename=$(curl -s "https://ci.appveyor.com/api/buildjobs/${jobid}/artifacts" | jq -r '.[0].fileName') && \
-    curl -s -o /tmp/radarr.tar.gz -L "https://ci.appveyor.com/api/buildjobs/${jobid}/artifacts/${filename}" && \
-    tar ixzf /tmp/radarr.tar.gz -C /app --strip-components=1 && \
-
-# clean up
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf \
-        /tmp/* \
-        /var/lib/apt/lists/* \
-        /var/tmp/*
+RUN     apt-get update \
+    &&  apt-get install -y \
+            libcurl3 \
+            libsqlite3-0 \
+            libmono-cil-dev \
+            mediainfo \
+    &&  radarr_tag=$(curl -sX GET "https://api.github.com/repos/Radarr/Radarr/releases" | \
+                        awk '/tag_name/{print $4;exit}' FS='[""]') \
+    &&  mkdir -p /app \
+    &&  curl -o /tmp/radarr.tar.gz -L \
+            "https://github.com/Radarr/Radarr/releases/download/${radarr_tag}/Radarr.develop.${radarr_tag#v}.linux.tar.gz" \
+    &&  tar ixzf /tmp/radarr.tar.gz -C /app --strip-components=1 \
+    # clean up
+    &&  apt-get autoremove -y \
+    &&  apt-get clean \
+    &&  rm -rf \
+            /tmp/* \
+            /var/lib/apt/lists/* \
+            /var/tmp/*
 
 # add local files
 COPY root/ /

--- a/root/etc/cont-init.d/20-install-new-version
+++ b/root/etc/cont-init.d/20-install-new-version
@@ -4,10 +4,11 @@ if [[ $VERSION != "" ]]; then
     echo "Installing new Radarr version: $VERSION"
     rm -rf /app/*
 
-    jobid=$(curl -s "https://ci.appveyor.com/api/projects/galli-leo/radarr-usby1/build/${VERSION}" | jq -r '.build.jobs[0].jobId') && \
-    filename=$(curl -s "https://ci.appveyor.com/api/buildjobs/${jobid}/artifacts" | jq -r '.[0].fileName') && \
-    curl -s -o /tmp/radarr.tar.gz -L "https://ci.appveyor.com/api/buildjobs/${jobid}/artifacts/${filename}" && \
-    tar ixzf /tmp/radarr.tar.gz -C /app --strip-components=1 && \
+    radarr_tag="v$VERSION"
+    mkdir -p /app
+    curl -o /tmp/radarr.tar.gz -L \
+            "https://github.com/Radarr/Radarr/releases/download/${radarr_tag}/Radarr.develop.${radarr_tag#v}.linux.tar.gz"
+    tar ixzf /tmp/radarr.tar.gz -C /app --strip-components=1
 
     rm -rf /tmp/*
     chown -R hotio:hotio /app


### PR DESCRIPTION
`.tar.gz` is no more the first artifact generated
by appveyor.
Using same procedure than linuxserver’s docker
to retrieve the tar.gz, ie, parsing github’s release
page